### PR TITLE
Man pages

### DIFF
--- a/man/alsa_in.0
+++ b/man/alsa_in.0
@@ -1,0 +1,100 @@
+.TH ALSA_IO "1" "!DATE!" "!VERSION!"
+.SH NAME
+\fBalsa_in\fR, \fBalsa_out\fR \- Jack clients that perform I/O with an alternate audio interface
+.SH SYNOPSIS
+\fBalsa_in\fR [\fIoptions\fR]
+.br
+\fBalsa_out\fR [\fIoptions\fR]
+
+.SH DESCRIPTION
+A JACK client that opens a specified audio interface (different to the
+one used by the JACK server, if any) and moves audio data between its
+JACK ports and the interface. alsa_in will provide data from the
+interface (potentially for capture); alsa_out will deliver data to it
+(for playback).
+
+The audio interface used by alsa_in/alsa_out does not need to be
+synchronized with JACK backend (or the hardware it might be using).
+alsa_in/alsa_out tries to resample the output stream in an attempt to
+compensate for drift between the two clocks.
+
+As of jack-0.116.3 this works almost perfectly. It takes some time, to reach
+absolute resample-rate stability. So give it some minutes (its intended to be
+running permanently anyways)
+
+.SH OPTIONS
+.TP
+\fB\-j \fI jack_client_name\fR
+.br
+Set Client Name.
+.TP
+\fB\-d \fI alsa_device\fR  
+.br
+Use this Soundcard.
+.TP
+\fB\-v\fR  
+.br
+Verbose, prints out resample coefficient and other parameters useful for debugging, every 500ms.
+also reports soft xruns. 
+.TP
+\fB\-i\fR  
+.br
+Instrumentation. This logs the 4 important parameters of the samplerate control algorithm every 1ms.
+You can pipe this into a file, and plot it. Should only be necessary, if it does not work as
+expected, and we need to adjust some of the obscure parameters, to make it work. 
+Find me on irc.freenode.org #jack in order to set this up correctly.
+.TP
+\fB\-c \fI channels\fR  
+.br
+Set Number of channels.
+.TP
+\fB\-r \fI sample_rate\fR  
+.br
+Set sample_rate. The program resamples as necessary.
+So you can connect a 44100 jackd to a soundcard only supporting
+48000. (default is jack sample_rate)
+.TP
+\fB\-p \fI period_size\fR  
+.br
+Set the period size. It is not related to the jackd period_size.
+Sometimes it affects the quality of the delay measurements.
+Setting this lower than the jackd period_size will only work, if you
+use a higher number of periods. 
+.TP
+\fB\-n \fI num_period\fR  
+.br
+Set number of periods. See note for period_size.
+.TP
+\fB\-q \fI quality\fR  
+.br
+Set the quality of the resampler from 0 to 4. can significanly reduce cpu usage.
+.TP
+\fB\-m \fI max_diff\fR  
+.br
+The value when a soft xrun occurs. Basically the window, in which
+the dma pointer may jitter. I don't think its necessary to play with this anymore. 
+.TP
+\fB\-t \fI target_delay\fR  
+.br
+The delay alsa_io should try to approach. Same as for max_diff. It will be setup based on \-p and \-n
+which is generally sufficient.
+.TP
+\fB\-s \fI smooth_array_size\fR  
+.br
+This parameter controls the size of the array used for smoothing the delay measurement. Its default is 256.
+If you use a pretty low period size, you can lower the CPU usage a bit by decreasing this parameter.
+However most CPU time is spent in the resampling so this will not be much.
+.TP
+\fB\-C \fI P Control Clamp\fR  
+.br
+If you have a PCI card, then the default value (15) of this parameter is too high for \-p64 \-n2... Setting it to 5 should fix that.
+Be aware that setting this parameter too low, lets the hf noise on the delay measurement come through onto the resamplerate, so this
+might degrade the quality of the output. (but its a threshold value, and it has been chosen, to mask the noise of a USB card,
+which has an amplitude which is 50 times higher than that of a PCI card, so 5 won't lose you any quality on a PCI card)
+.TP
+\fB\-S \fI server_name\fR 
+.br
+Server to connect to. This option permits to attach to a named jack2 server.
+
+.SH AUTHOR
+Torben Hohn

--- a/man/alsa_out.0
+++ b/man/alsa_out.0
@@ -1,0 +1,1 @@
+.so man1/alsa_in.1

--- a/man/fill_template
+++ b/man/fill_template
@@ -1,0 +1,7 @@
+#!/bin/sh
+d=""
+[ -z "$SOURCE_DATE_EPOCH" ] || d=--date=@$SOURCE_DATE_EPOCH
+
+for i in *.0 ; do
+   sed -e "s/!VERSION!/${1}/g" -e "s/!DATE!/`date $d '+%B %Y'`/g" < ${i} > ${i%%0}1
+done

--- a/man/jack_bufsize.0
+++ b/man/jack_bufsize.0
@@ -1,0 +1,14 @@
+.TH JACK_BUFSIZE "1" "!DATE!" "!VERSION!"
+.SH NAME
+jack_bufsize \- JACK toolkit client to change the JACK buffer size
+.SH SYNOPSIS
+.B jack_bufsize bufsize
+.SH DESCRIPTION
+.B jack_bufsize
+jack_bufsize sets the size of the buffer (frames per period) used in JACK. 
+This change happens on-line (the JACK server and its clients do not need to be 
+restarted).
+.br
+When invoked without arguments, it prints the current bufsize, and exits.
+
+

--- a/man/jack_connect.0
+++ b/man/jack_connect.0
@@ -1,0 +1,11 @@
+.TH JACK_CONNECT "1" "!DATE!" "!VERSION!"
+.SH NAME
+\fBjack_connect\fR, \fBjack_disconnect\fR \- JACK toolkit clients for connecting & disconnecting ports
+.SH SYNOPSIS
+\fB jack_connect\fR [ \fI-s\fR | \fI--server servername\fR ] [\fI-h\fR | \fI--help\fR ] port1 port2
+\fB jack_disconnect\fR [ \fI-s\fR | \fI--server servername\fR ] [\fI-h\fR | \fI--help\fR ] port1 port2
+.SH DESCRIPTION
+\fBjack_connect\fR connects the two named ports. \fBjack_disconnect\fR disconnects the two named ports.
+.SH RETURNS
+The exit status is zero if successful, 1 otherwise
+

--- a/man/jack_disconnect.0
+++ b/man/jack_disconnect.0
@@ -1,0 +1,1 @@
+.so man1/jack_connect.1

--- a/man/jack_freewheel.0
+++ b/man/jack_freewheel.0
@@ -1,0 +1,16 @@
+.TH JACK_FREEWHEEL "1" "!DATE!" "!VERSION!"
+.SH NAME
+jack_freewheel \- JACK toolkit client to control freewheeling mode
+.SH SYNOPSIS
+.B jack_freewheel [y|n]
+.SH DESCRIPTION
+.B jack_freewheel
+Turns freewheeling mode on (y) or off (n). While in freewheeling mode,
+the JACK server does not wait in between process() calls, and does not
+read or write data from/to any audio interface. That results in the JACK graph
+processing data as fast as possible. Freewheeling makes fast exports to 
+files possible.
+.PP
+There is no useful reason to use this tool other than testing. JACK
+clients that use freewheeling will turn it on and off themselves.
+

--- a/man/jack_impulse_grabber.0
+++ b/man/jack_impulse_grabber.0
@@ -1,0 +1,11 @@
+.TH JACK_IMPULSE_GRABBER "1" "!DATE!" "!VERSION!"
+.SH NAME
+jack_impulse_grabber \- JACK toolkit client to grab an impulse (response)
+.SH SYNOPSIS
+\fBjack_impulse_grabber\fR \fB-d\fR \fIduration\fR [\fI-f\fR (C|gnuplot)]
+.SH DESCRIPTION
+\fBjack_impulse_grabber\fR is a JACK example client for collecting
+impulses recordings from JACK ports.
+
+
+

--- a/man/jack_iodelay.0
+++ b/man/jack_iodelay.0
@@ -1,0 +1,60 @@
+.TH JACK_IODELAY "1" "!DATE!" "!VERSION!"
+.SH NAME
+jack_iodelay \- JACK toolkit client to measure roundtrip latency
+.SH SYNOPSIS
+.B jack_iodelay
+.SH DESCRIPTION
+.B jack_iodelay
+will create one input and one output port, and then
+measures the latency (signal delay) between them. For this to work,
+the output port must be connected to its input port. The measurement
+is accurate to a resolution of greater than 1 sample.
+.PP
+The expected use is to connect jack_iodelay's output port to a
+hardware playback port, then use a physical loopback cable from the
+corresponding hardware output connector to an input connector, and to
+connect that corresponding hardware capture port to jack_iodelay's
+input port. This creates a roundtrip that goes through any
+analog-to-digital and digital-to-analog converters that are present in
+the audio hardware.
+.PP
+Although the hardware loopback latency is the expected use, it is also
+possible to use jack_iodelay to measure the latency along any fully
+connected signal path, such as those involving other JACK clients.
+.PP
+Once jack_iodelay completes its measurement it will print the total
+latency it has detected. This will include the JACK buffer length in
+addition to any other latency in the signal path. It will continue to
+print the value every 0.5 seconds so that if you wish you can
+vary aspects of the signal path to see their effect on the measured
+latency.
+.PP
+If no incoming signal is detected from the input port, jack_iodelay
+will print 
+.PP
+\fT Signal below threshold... .\fR
+.PP
+every second until this changes (e.g. until you establish the correct
+connections).
+.PP
+To use the value measured by jack_iodelay with the -I and -O arguments
+of a JACK backend (also called Input Latency and Output Latency in the
+setup dialog of qjackctl), you must subtract the JACK buffer size from
+the result. The buffer size is determined by multiplying the number of
+frames per period (given to the jackd backend by the -p or --period
+option) by the number of periods per buffer (given to the jackd
+backend by the -n or --nperiods option).  Note that JACK2 will add an
+implicit additional period when using the default asynchronous mode,
+so for JACK1 or JACK2 in synchronous mode, the buffer size is n*p, but
+for JACK2 in asynchronous mode the buffer size is (n+1)*p.  Once the
+JACK buffer size is subtracted from the measured latency, the result
+is the "extra" latency due to the interface hardware. Then, if you
+believe that the latency is equally distributed between the input and
+output parts of your audio hardware (extremely likely), divide the
+result by two and use that for input and output latency
+values. Doing this measurement will enable JACK clients that use the
+JACK latency API to accurately position/delay audio to keep signals
+synchronized even when there are inherent delays in the end-to-end
+signal pathways.
+.SH AUTHOR
+Originally written in C++ by Fons Adriaensen, ported to C by Torben Hohn.

--- a/man/jack_load.0
+++ b/man/jack_load.0
@@ -1,0 +1,28 @@
+.TH JACK_LOAD "1" "!DATE!" "!VERSION!"
+.SH NAME
+jack_load \- JACK toolkit client for loading in-process clients
+.SH SYNOPSIS
+\fBjack_load\fR [ \fI-i\fR initstring ] [ \fI-s\fR servername ] [\fI-w\fR ] client-name so-name [ initstring ]
+.SH DESCRIPTION
+\fBjack_load\fR is a JACK toolkit client. It loads the specified plugin and creates an in-process client.
+.SH ARGUMENTS
+.PP
+The client-name must be a currently unused client name.
+.PP
+The so-name is the name of file that client code is stored in (typically, \fIclientname.so\fR)
+.SH OPTIONS
+.TP
+\fB-i\fR, \fB--init\fR init-string
+.br
+initialization string passed to the in-process client. Note that this can also be specified as the last argument on the command line.
+.TP
+\fB-s\fR, \fB--server\fR servername
+.br
+Name of JACK server to connect to
+.TP
+\fB-w\fR, \fB--wait\fR
+Wait for a signal (eg. from Ctrl-c) and then unload the client.
+.SH AUTHOR
+Jeremy Hall
+
+

--- a/man/jack_lsp.0
+++ b/man/jack_lsp.0
@@ -1,0 +1,47 @@
+.TH JACK_LSP "1" "!DATE!" "!VERSION!"
+.SH NAME
+jack_lsp \- JACK toolkit client to list information on ports
+.SH SYNOPSIS
+\fBjack_lsp\fR [ \fI-s\fR | \fI--server\fR servername ] [ \fI-AclLptvh\fR ]
+.SH DESCRIPTION
+\fBjack_lsp\fR lists all known ports associated with a JACK
+server. It can also optionally list various kinds of information about each port.
+.SH OPTIONS
+.TP
+\fB-s\fR, \fB--server\fR \fIservername\fR
+.br
+Connect to the jack server named \fIservername\fR
+.TP
+\fB-A\fR, \fB--aliases\fR
+.br
+List aliases for each port
+.TP
+\fB-c\fR, \fB--connections\fR
+.br
+List connections to/from each port
+.TP
+\fB-l\fR, \fB--latency\fR
+.br
+Display per-port latency in frames at each port
+.TP
+\fB-L\fR, \fI--latency\fR
+.br
+Display total latency in frames at each port
+.TP
+\fB-p\fR, \fB--properties\fR
+.br
+Display port properties. Output may include input|output, can-monitor, physical, terminal
+.TP
+\fB-t\fR, \fB--type\fR
+.br
+Display port type
+.TP
+\fB-h\fR, \fB--help\fR
+.br
+Display help/usage message
+.TP
+\fB-v\fR, \fB--version\fR
+.br
+Output version information and exit
+
+

--- a/man/jack_metro.0
+++ b/man/jack_metro.0
@@ -1,0 +1,40 @@
+.TH JACK_METRO "1" "!DATE!" "!VERSION!"
+.SH NAME
+jack_metro \- JACK toolkit metronome
+.SH SYNOPSIS
+\fBjack_metro\fR [ \fI-n\fR name ] [ \fI-f\fR hz ] [ \fI-D\fR msecs ] [\fI-a\fR % ] [ \fI-d\fR % ] \fI-b\fR bpm 
+.SH DESCRIPTION
+\fBjack_metro\fR is a simple metronome for JACK. It generates a
+synthetic "tick" sound for every beat. Note that is does \fBnot\fR
+connect its output port by default - to hear the sound it makes you must
+connect them using some other tool.
+.SH OPTIONS
+.TP
+\fB-n\fR, \fB--name\fR
+.br
+Specify a name for this instance of the metronome.
+.TP
+\fB-f\fR, \fB--frequency\fR Hz
+.br
+Define the frequency of the "tick" in Hz.
+.TP
+\fB-D\fR, \fB--duration\fR msecs
+.br
+Define the duration of the "tick" in milliseconds.
+.TP
+\fB-a\fR, \fB--attack\fR %-age
+.br
+Define the duration of the attack phase of the "tick" as a percentage
+of the duration.
+.TP
+\fB-d\fR, \fB--decay\fR %-age
+.br
+Define the duration of the decay phase of the "tick" as a percentage
+of the duration.
+.TP
+\fB--b\fR, \fB--bpm\fR bpm
+.br
+Define the number of beats per minute.
+.SH AUTHOR
+Anthony Van Groningen
+

--- a/man/jack_monitor_client.0
+++ b/man/jack_monitor_client.0
@@ -1,0 +1,18 @@
+.TH JACK_CONNECT "1" "!DATE!" "!VERSION!"
+.SH NAME
+jack_monitor_client \- The JACK Audio Connection Kit example client
+.SH SYNOPSIS
+.B jack_monitor_client
+client-name
+.PP
+The client-name must be the name of a existing client that monitoring is 
+to be enabled for.
+.SH DESCRIPTION
+.B jack_monitor_client
+is an example client for the JACK Audio Connection Kit. It enables
+monitoring for the specified client.
+.SH AUTHOR
+Jeremy Hall
+.PP
+This manpage was written by Robert Jordens <jordens@debian.org> for Debian.
+

--- a/man/jack_netsource.0
+++ b/man/jack_netsource.0
@@ -1,0 +1,109 @@
+.TH JACK_NETSOURCE "1" "!DATE!" "!VERSION!"
+.SH NAME
+jack_netsource \- Netjack Master client for one slave
+.SH SYNOPSIS
+\fBjack_netsource\fR [ \fI-H\fR hostname ] [ \fIoptions\fR ]
+
+.SH DESCRIPTION
+\fBjack_netsource\fR The Master side of a netjack connection. Represents the slave jackd -dnet in the master jack graph.
+Most connection parameters are configured via the netsource, and the slave will set itself up according to the commandline
+option given to jack_netsource.
+.br
+Netjack allows low latency audio connections over general IP networks. When using celt for compression, it is even possible
+to establish transatlantic links, with latencies not much over the actual ping time. 
+.br
+But the main usecase is of course a LAN, where it can achieve one jack period of latency.
+
+.SH OPTIONS
+.TP
+\fB-h\fR this help text
+.TP
+\fB-H\fR \fIslave host\fR
+.br
+Host name of the slave JACK
+.TP
+\fB-o\fR \fInum channels\fR
+.br
+Number of audio playback channels
+.TP
+\fB-i\fR \fInum channels\fR
+.br
+Number of audio capture channels
+.TP
+\fB-O\fR \fInum channels\fR
+.br
+Number of midi playback channels
+.TP
+\fB-I\fR \fInum channels\fR
+.br
+Number of midi capture channels
+.TP
+\fB-n\fR \fIperiods\fR
+.br
+Network latency in JACK periods
+.TP
+\fB-p\fR \fIport\fR
+.br
+UDP port that the slave is listening on
+.TP
+\fB-r\fR \fIreply port\fR
+.br
+UDP port that we are listening on
+.TP
+\fB-B\fR \fIbind port\fR
+.br
+reply port, for use in NAT environments
+.TP
+\fB-b\fR \fIbitdepth\fR
+.br
+Set transport to use 16bit or 8bit
+.TP
+\fB-c\fR \fIbytes\fR
+.br
+Use CELT encoding with <bytes> per period and channel
+.TP
+\fB-m\fR \fImtu\fR
+.br
+Assume this mtu for the link
+.TP
+\fB-R\fR \fIN\fR
+.br
+Redundancy: send out packets N times.
+.TP
+\fB-e\fR
+.br
+skip host-to-network endianness conversion
+.TP
+\fB-N\fR \fIjack name\fR
+.br
+Reports a different client name to jack
+.TP
+.TP
+\fB-s\fR, \fB--server\fR \fIservername\fR
+.br
+Connect to the jack server named \fIservername\fR
+.TP
+\fB-h\fR, \fB--help\fR
+.br
+Display help/usage message
+.TP
+\fB-v\fR, \fB--version\fR
+.br
+Output version information and exit
+
+
+.SH EXAMPLES
+
+.PP
+run a 4 audio channel bidirectional link with one period of latency and no midi channels. Audio data is flowing uncompressed over the wire:
+.br
+On \fIhostA\fR:
+.IP
+\fBjackd \-d alsa \fR
+.br
+\fBjack_netsource \-H hostB -n1 -i4 -o4 -I0 -O0 \fR
+.PP
+On \fIhostB\fR:
+.IP
+\fBjackd \-d net \fR
+

--- a/man/jack_property.0
+++ b/man/jack_property.0
@@ -1,0 +1,64 @@
+.TH JACK_PROPERTY "1" "!DATE!" "!VERSION!"
+.SH NAME
+jack_property \- JACK client to list, set and delete metadata information
+.SH SYNOPSIS
+\fBjack_property\fR -l
+.br
+\fBjack_property\fR [ -c | -p ] -l \fIidentifier\fR 
+.br
+\fBjack_property\fR [ -c | -p ] -l \fIidentifier\fR \fIkey\fR
+.br
+\fBjack_property\fR [ -c | -p ] -s \fIidentifier\fR \fIkey\fR \fIvalue\fR [ \fItype\fR ]
+.br
+\fBjack_property\fR [ -c | -p ] -d \fIidentifier\fR 
+.br
+\fBjack_property\fR [ -c | -p ] -d \fIidentifier\fR \fIkey\fR
+.br
+\fBjack_property\fR -D 
+.SH DESCRIPTION
+\fBjack_property\fR can be used to list, set and delete any and all metadata associated with the ports
+and clients of a JACK server.
+.P
+There are three main ways to use the command. The \fB-l\fR option is used to list existing metadata. The \fB-s\fR option is used
+to set metadata. The \fB-d/-D\fR options are used to delete metadata.
+.P
+The \fIidentifier\fR is normally a UUID (UUIDs for ports and clients can be shown with jack_lsp(1)). If the \fB-c\fR option is used, then \fIidentifier\fR will
+be interpreted as a client name, and its UUID will be looked up internally and used for the relevant metadata operation. If the \fB-p\fR option is used, then \fIidentifier\fR will
+be interpreted as a port name and its UUID  will be looked up internally and used for the relevant metadata operation.
+.P
+The \fIkey\fR is an arbitrary string that identifies the metadata to be operated upon.
+.P
+The \fIvalue\fR is an arbitrary string that defines the value of the metadata to be created.
+.P
+The \fItype\fR is an optional MIME type, given as a string. An empty type for a piece of metadata results in it being interpreted as "text/UTF-8". 
+.SH OPTIONS
+.TP 6
+-l
+list all metadata currently defined
+.TP
+-l identifier
+list all metadata currently defined for \fIidentifier\fR
+.TP
+-l identifier key
+show the value of the metadata associated with key for \fIidentifier\fR
+.TP
+-d identifier
+deletes all metadata for \fIidentifier\fR
+.TP
+-d identifier key
+deletes the metadata associated with \fIkey\fR for \fIidentifier\fR
+.TP
+-D
+delete all currently defined metadata
+.TP
+-s identifier key value [ type ]
+sets the metadata associated with \fIkey\fR to \fIvalue\fR for \fIidentifer\fR, with its type set to \fItype\fR if given
+.TP
+-c 
+interpret a given identifier as a client name rather than a UUID
+.TP 
+-p
+interpret a given identifier as a port name rather than a UUID
+
+
+

--- a/man/jack_samplerate.0
+++ b/man/jack_samplerate.0
@@ -1,0 +1,9 @@
+.TH JACK_SAMPLERATE "1" "!DATE!" "!VERSION!"
+.SH NAME
+jack_samplerate \- JACK toolkit client to print current samplerate
+.SH SYNOPSIS
+.B jack_samplerate
+.SH DESCRIPTION
+.B jack_samplerate prints the current samplerate, and exits.
+
+

--- a/man/jack_showtime.0
+++ b/man/jack_showtime.0
@@ -1,0 +1,13 @@
+.TH JACK_SHOWTIME "1" "!DATE!" "!VERSION!"
+.SH NAME
+jack_showtime \- The JACK Audio Connection Kit example client
+.SH SYNOPSIS
+.B jack_showtime
+.SH DESCRIPTION
+.B jack_showtime
+prints the current timebase information to stdout
+.SH AUTHOR
+Paul Davis
+.PP
+This manpage was written by Stefan Schwandter <swan@debian.org>
+

--- a/man/jack_simple_client.0
+++ b/man/jack_simple_client.0
@@ -1,0 +1,20 @@
+.TH JACK_CONNECT "1" "!DATE!" "!VERSION!"
+.SH NAME
+jack_simple_client \- The JACK Audio Connection Kit example client
+.SH SYNOPSIS
+.B jack_simple_client
+client-name
+.PP
+The client-name must be a yet unused client name.
+.SH DESCRIPTION
+.B jack_simple_client
+is an example client for the JACK Audio Connection Kit. It creates two
+ports (client-name:input and client-name:output) that pass the data
+unmodified.
+.SH EXAMPLE
+jack_simple_client in_process_test
+.SH AUTHOR
+Jeremy Hall
+.PP
+This manpage was written by Robert Jordens <jordens@debian.org> for Debian.
+

--- a/man/jack_transport.0
+++ b/man/jack_transport.0
@@ -1,0 +1,13 @@
+.TH JACK_TRANSPORT "1" "!DATE!" "!VERSION!"
+.SH NAME
+jack_transport \- JACK toolkit client for transport control
+.SH SYNOPSIS
+.B jack_transport
+.SH DESCRIPTION
+.B jack_transport
+is a toolkit client for the JACK Audio Connection Kit. It provides command-line
+control over the JACK transport system. Type help at jack_transport's
+command prompt to see the available commands.
+.SH AUTHOR
+Jeremy Hall
+

--- a/man/jack_unload.0
+++ b/man/jack_unload.0
@@ -1,0 +1,19 @@
+.TH JACK_UNLOAD "1" "!DATE!" "!VERSION!"
+.SH NAME
+jack_unload \- The JACK Audio Connection Kit example client
+.SH SYNOPSIS
+.B jack_unload 
+client-name
+.PP
+The client-name must be the name of a loaded client that can be unloaded.
+.SH DESCRIPTION
+.B jack_unload
+is the counterpart to 
+.B jack_load
+and unloads the specified client.
+.SH EXAMPLE
+.B jack_unload in_process_test
+.SH AUTHOR
+Jeremy Hall
+.PP
+This manpage was written by Robert Jordens <jordens@debian.org> for Debian.

--- a/man/jack_wait.0
+++ b/man/jack_wait.0
@@ -1,0 +1,41 @@
+.TH JACK_WAIT "1" "!DATE!" "!VERSION!"
+.SH NAME
+jack_wait \- JACK toolkit client to check and wait for existence/exit of jackd.  
+.SH SYNOPSIS
+\fBjack_wait\fR [ \fI-s\fR | \fI--server\fR servername ] [ \fI-t\fR | \fI--timeout\fR timeout_seconds [ \fI-cqwhv\fR ]
+.SH DESCRIPTION
+\fBjack_wait\fR When invoked with \fI-c\fR it only checks for the existence of a jack server. When invoked with \fI-w\fR the
+program will wait for a jackd to be available.
+The \fI-q\fR makes it wait for the jackd to exit.
+
+.SH OPTIONS
+.TP
+\fB-w\fR, \fB--wait\fR
+.br
+Wait for jackd to be available.
+.TP
+\fB-q\fR, \fB--quit\fR
+.br
+Wait for jackd quit.
+.TP
+\fB-c\fR, \fB--check\fR
+.br
+Only check for existence of jackd, and exit.
+.TP
+\fB-s\fR, \fB--server\fR \fIservername\fR
+.br
+Connect to the jack server named \fIservername\fR
+.TP
+\fB-t\fR, \fB--timeout\fR \fItimeout_seconds\fR
+.br
+Only wait \fItimeout_seconds\fR.
+.TP
+\fB-h\fR, \fB--help\fR
+.br
+Display help/usage message
+.TP
+\fB-v\fR, \fB--version\fR
+.br
+Output version information and exit
+
+

--- a/man/jackrec.0
+++ b/man/jackrec.0
@@ -1,0 +1,23 @@
+.TH JACKREC "1" "!DATE!" "!VERSION!"
+.SH NAME
+jackrec \- JACK toolkit client for recording audio
+.SH SYNOPSIS
+.B jackrec
+\-f filename \-d seconds [ \-b bitdepth ] port1 [ port2 ... ]
+.SH DESCRIPTION
+.B jackrec is a basic, but useful, audio recorder that will record
+audio from 1 or more JACK ports to a file on disk. The file format is
+always RIFF/WAV, with samples stored as signed integers. The sample
+bit depth can be selected using the \fI-b\fR option. The file will
+have as many channels as there are ports specified on the command line
+- each channel will contain the data recorded from one port. The user
+should generally specify the duration (in seconds) using the \fI-d\fR
+option. If not specified, jackrec will record until terminated by a
+signal (eg. from Ctrl-c).
+.PP
+This application is not intended to be a heavy duty audio recorder,
+and originated as an example client to show how to handle threading
+and disk I/O in a JACK client. However, it is a useful, simple
+recorder and is included in the JACK toolkit as a result.
+
+


### PR DESCRIPTION
Use git-filter-repo to extract all relevant [man pages from the jack2 repository](https://github.com/jackaudio/jack2/tree/93619ed0c528e0f1e30513505bc0e8611c3ec2e8/man). This excludes the jackd man page and wscript.

Closes #4 