### PR TITLE
Remove calls to deprecated ALSA function

### DIFF
--- a/tools/alsa_in.c
+++ b/tools/alsa_in.c
@@ -265,12 +265,6 @@ static int set_swparams(snd_pcm_t *handle, snd_pcm_sw_params_t *swparams, int pe
 		printf("Unable to set avail min for capture: %s\n", snd_strerror(err));
 		return err;
 	}
-	/* align all transfers to 1 sample */
-	err = snd_pcm_sw_params_set_xfer_align(handle, swparams, 1);
-	if (err < 0) {
-		printf("Unable to set transfer align for capture: %s\n", snd_strerror(err));
-		return err;
-	}
 	/* write the parameters to the playback device */
 	err = snd_pcm_sw_params(handle, swparams);
 	if (err < 0) {

--- a/tools/alsa_out.c
+++ b/tools/alsa_out.c
@@ -266,12 +266,6 @@ static int set_swparams(snd_pcm_t *handle, snd_pcm_sw_params_t *swparams, int pe
 		printf("Unable to set avail min for capture: %s\n", snd_strerror(err));
 		return err;
 	}
-	/* align all transfers to 1 sample */
-	err = snd_pcm_sw_params_set_xfer_align(handle, swparams, 1);
-	if (err < 0) {
-		printf("Unable to set transfer align for capture: %s\n", snd_strerror(err));
-		return err;
-	}
 	/* write the parameters to the playback device */
 	err = snd_pcm_sw_params(handle, swparams);
 	if (err < 0) {


### PR DESCRIPTION
Remaining, still applicable fix taken from https://github.com/jackaudio/tools/pull/7
All whitespace related fixes and commits for already fixed problems have been disregarded.

Relates to #43