### PR TITLE
Optional readline

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,24 @@ However, testing is very much welcomed!*
 
 The project requires the following dependencies:
 
-* [alsa-lib](https://www.alsa-project.org/wiki/Main_Page) (optional buildtime/
-  runtime dependency for `alsa_in` and `alsa_out`)
-* [jack1](https://github.com/jackaudio/jack1) or [jack2](https://github.com/jackaudio/jack2)
+* [alsa-lib](https://www.alsa-project.org/wiki/Main_Page) (required when
+  building `alsa_in` and `alsa_out` or ZALSA internal clients)
+* [jack1](https://github.com/jackaudio/jack1) or
+  [jack2](https://github.com/jackaudio/jack2)
 * [opus](https://www.opus-codec.org/) (optional buildtime/ runtime dependency
   for `jack_netsource`)
-* [readline](https://tiswww.case.edu/php/chet/readline/rltop.html)
-* [libsamplerate](https://libsndfile.github.io/libsamplerate/)
-* [libsndfile](https://libsndfile.github.io/libsndfile/)
-* [libzita-alsa-pcmi](https://kokkinizita.linuxaudio.org/linuxaudio/)
-* [libzita-resampler](https://kokkinizita.linuxaudio.org/linuxaudio/)
+* [readline](https://tiswww.case.edu/php/chet/readline/rltop.html) (optional
+  buildtime/ runtime dependency for `jack_transport`)
+* [libsamplerate](https://libsndfile.github.io/libsamplerate/) (required when
+  building `alsa_in` and `alsa_out` or `jack_netsource`)
+* [libsndfile](https://libsndfile.github.io/libsndfile/) (required when
+  building `jack_rec`)
+* [libzita-alsa-pcmi](https://kokkinizita.linuxaudio.org/linuxaudio/) (required
+  when building ZALSA internal clients)
+* [libzita-resampler](https://kokkinizita.linuxaudio.org/linuxaudio/) (required
+  when building ZALSA internal clients)
+
+For all available options please refer to [meson_options.txt](meson_options.txt).
 
 ## Building
 

--- a/meson.build
+++ b/meson.build
@@ -27,7 +27,7 @@ jack_version = dep_jack.version()
 lib_jackserver = cc.find_library('jackserver', required: true)
 lib_jacknet = cc.find_library('jacknet', required: get_option('jack_net'))
 dep_opus = dependency('opus', version: '>=0.9.0', required: get_option('opus_support'))
-dep_readline = dependency('readline')
+dep_readline = dependency('readline', required: get_option('readline_support'))
 dep_samplerate = dependency('samplerate', required: libsamplerate_required)
 dep_sndfile = dependency('sndfile', required: get_option('jack_rec'))
 dep_threads = dependency('threads')
@@ -56,6 +56,11 @@ if get_option('opus_support').enabled() or (get_option('opus_support').auto() an
   opus_support = true
 endif
 
+readline_support = false
+if get_option('readline_support').enabled() or (get_option('readline_support').auto() and dep_readline.found())
+  readline_support = true
+endif
+
 build_jack_rec = false
 if get_option('jack_rec').enabled() or (get_option('jack_rec').auto() and dep_sndfile.found())
   build_jack_rec = true
@@ -76,6 +81,7 @@ if build_jack_netsource
   message('Build jack_netsource with opus support: ' + opus_support.to_string())
 endif
 message('Build jack_rec executable: ' + build_jack_rec.to_string())
+message('Build jack_transport with readline support: ' + readline_support.to_string())
 message('Build ZALSA internal clients: ' + build_zalsa.to_string())
 
 conf_data = configuration_data()

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,4 +3,5 @@ option('jack_net', type: 'feature', value: 'auto', description: 'Build the jack_
 option('jack_netsource', type: 'feature', value: 'auto', description: 'Build the jack_netsource executable (default: auto)')
 option('jack_rec', type: 'feature', value: 'auto', description: 'Build the jack_rec executable (default: auto)')
 option('opus_support', type: 'feature', value: 'auto', description: 'Build the jack_netsource executable with opus support (default: auto)')
+option('readline_support', type: 'feature', value: 'auto', description: 'Build the jack_transport executable with readline support (default: auto)')
 option('zalsa', type: 'feature', value: 'auto', description: 'Build the ZALSA internal client (default: auto)')

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -156,11 +156,18 @@ exe_jack_session_notify = executable(
   install: false
 )
 
+jack_transport_c_args = c_args_common
+jack_transport_deps = [dep_jack]
+if readline_support
+  jack_transport_c_args += ['-DHAVE_READLINE']
+  jack_transport_deps += [dep_readline]
+endif
+
 exe_jack_transport = executable(
   'jack_transport',
-  c_args: c_args_common + ['-DHAVE_READLINE'],
+  c_args: jack_transport_c_args,
   sources: ['transport.c'],
-  dependencies: [dep_jack, dep_readline],
+  dependencies: jack_transport_deps,
   install: true
 )
 


### PR DESCRIPTION
Make readline support for `jack_transport` selectable and update the dependency information in the README.