### PR TITLE
Format code using clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,7 @@
+---
+BasedOnStyle:  WebKit
+AlignAfterOpenBracket: Align
+ColumnLimit: 120
+CompactNamespaces: true
+TabWidth: 4
+UseTab: ForIndentation

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# EditorConfig: https://editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{c,cc,cpp,h}]
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
This adds an editorconfig (see https://editorconfig-specification.readthedocs.io/) file and a clang-format configuration (see https://clang.llvm.org/docs/ClangFormatStyleOptions.html).

All files are formatted using the clang-format configuration file.

Fixes #42