### PR TITLE
Ignore known deprecated jack-session warnings

### DIFF
--- a/example-clients/meson.build
+++ b/example-clients/meson.build
@@ -141,6 +141,7 @@ exe_jack_simple_session_client = executable(
   'jack_simple_session_client',
   sources: ['simple_session_client.c'],
   dependencies: [dep_jack],
+  c_args: ['-Wno-deprecated-declarations'],
   install: false
 )
 

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -153,6 +153,7 @@ exe_jack_session_notify = executable(
   'jack_session_notify',
   sources: ['session_notify.c'],
   dependencies: [dep_jack],
+  c_args: ['-Wno-deprecated-declarations'],
   install: false
 )
 


### PR DESCRIPTION
I have set these tools as not installed by default in a previous commit, but still build them because there might be people interested on them (so IMO we should ensure they still build at least).

They pollute the build stage with warnings about being deprecated though, which we know about.
So just ignore them.
