### PR TITLE
Rely on compile and function checks for different JACK implementations and update README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 - Add jack2-only example-clients
 - Add license files for example-clients and tools and imported zalsa files
 - Add meson build system
+- Add CI builds against jack1 and jack2 in an Arch Linux container
+- Add supported jack version to project description: jack1 (>=0.126.0), jack2
+  (>=1.9.20), pipewire-jack (>=0.3.44)
+- Add support to compile against different jack implementations based on
+  available features and function definitions
 
 ### Changed
 - Consolidate example-clients and tools with the versions in

--- a/README.md
+++ b/README.md
@@ -5,27 +5,16 @@ been tracked in the
 [example-clients](https://github.com/jackaudio/example-clients) and
 [tools](https://github.com/jackaudio/tools) repositories in the past.
 
-**WARNING**:
-
-*In its current form, this project has conflicting files with the
-[jack1](https://github.com/jackaudio/jack1) and
-[jack2](https://github.com/jackaudio/jack2) projects (when installed).
-The efforts for consolidating and eventually removing the example-clients and
-tools from both projects are tracked in
-[jackaudio/jack1#109](https://github.com/jackaudio/jack1/issues/109) and
-[jackaudio/jack2#805](https://github.com/jackaudio/jack2/issues/805).
-The installation and use of this project is therefore deemed experimental until
-both issues are resolved.
-However, testing is very much welcomed!*
-
 ## Dependencies
 
 The project requires the following dependencies:
 
 * [alsa-lib](https://www.alsa-project.org/wiki/Main_Page) (required when
   building `alsa_in` and `alsa_out` or ZALSA internal clients)
-* [jack1](https://github.com/jackaudio/jack1) or
-  [jack2](https://github.com/jackaudio/jack2)
+* [jack1](https://github.com/jackaudio/jack1) >= 0.126.0,
+  [jack2](https://github.com/jackaudio/jack2) >= 1.9.20, or
+  [pipewire-jack](https://gitlab.freedesktop.org/pipewire/pipewire) >= 0.3.44
+  (other versions may work but are not supported)
 * [opus](https://www.opus-codec.org/) (optional buildtime/ runtime dependency
   for `jack_netsource`)
 * [readline](https://tiswww.case.edu/php/chet/readline/rltop.html) (optional
@@ -39,7 +28,9 @@ The project requires the following dependencies:
 * [libzita-resampler](https://kokkinizita.linuxaudio.org/linuxaudio/) (required
   when building ZALSA internal clients)
 
-For all available options please refer to [meson_options.txt](meson_options.txt).
+For all available options please refer to
+[meson_options.txt](meson_options.txt) or run `meson configure` in the project
+directory.
 
 ## Building
 

--- a/example-clients/meson.build
+++ b/example-clients/meson.build
@@ -106,9 +106,14 @@ if build_jack_net
   )
 endif
 
+if has_jackctl_server_create2
+  c_args_jack_server_control = c_args_common + ['-D__JACK2__']
+else
+  c_args_jack_server_control = c_args_common + ['-D__JACK1__']
+endif
 exe_jack_server_control = executable(
   'jack_server_control',
-  c_args: c_args_common,
+  c_args: c_args_jack_server_control,
   sources: ['server_control.c'],
   dependencies: [dep_jack, lib_jackserver],
   install: true

--- a/meson.build
+++ b/meson.build
@@ -81,6 +81,7 @@ dep_sndfile = dependency('sndfile', required: get_option('jack_rec'))
 dep_threads = dependency('threads')
 lib_zita_alsa_pcmi = cc.find_library('zita-alsa-pcmi', required: get_option('zalsa'))
 lib_zita_resampler = cc.find_library('zita-resampler', required: get_option('zalsa'))
+has_ppoll = cc.has_function('ppoll', prefix: '#define _GNU_SOURCE\n#include <sys/poll.h>')
 
 build_alsa_in_out = false
 if get_option('alsa_in_out').enabled() or (

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'jack-example-tools',
   ['c', 'cpp'],
-  meson_version: '>=0.50.0',
+  meson_version: '>=0.58.0',
   license: ['GPL2+'],
   version: '0.1.0',
 )
@@ -21,11 +21,59 @@ if get_option('alsa_in_out').enabled() or get_option('jack_netsource').enabled()
   libsamplerate_required = true
 endif
 
-dep_alsa = dependency('alsa', version: '>=1.0.18', required: alsa_required)
 dep_jack = dependency('jack')
-jack_version = dep_jack.version()
+
+jack_implementation = ''
+jack_implementation = dep_jack.get_variable('jack_implementation')
+if jack_implementation == ''
+  warning('No compatible jack implementation detected. This may mean conflicting files when installing!')
+endif
+
+has_jack1_internal_client = cc.compiles(
+  '''
+  #include <stdio.h>
+  #include <jack/jack.h>
+  #include <jack/intclient.h>
+
+  int main (int argc, char *argv[]) {
+    const char *client_name;
+    jack_client_t *client;
+    jack_status_t status;
+    jack_intclient_t intclient;
+
+    client_name = "foo";
+    client = jack_client_open(client_name, JackNoStartServer, &status);
+    jack_internal_client_handle(client, client_name, &status, &intclient);
+  }
+  '''
+)
+message('Provides jack1-style jack_internal_client_handle(): ' + has_jack1_internal_client.to_string())
+
+has_jack2_internal_client = cc.compiles(
+  '''
+  #include <jack/jack.h>
+  #include <jack/intclient.h>
+
+  int main (int argc, char *argv[]) {
+    const char *client_name;
+    jack_client_t *client;
+    jack_status_t status;
+    jack_intclient_t intclient;
+
+    client_name = "foo";
+    client = jack_client_open(client_name, JackNoStartServer, &status);
+    intclient = jack_internal_client_handle (client, client_name, &status);
+  }
+  '''
+)
+message('Provides jack2-style jack_internal_client_handle(): ' + has_jack2_internal_client.to_string())
+
 lib_jackserver = cc.find_library('jackserver', required: true)
+has_jackctl_server_create2 = cc.has_function('jackctl_server_create2', dependencies: lib_jackserver, prefix: '#include <jack/control.h>')
+
 lib_jacknet = cc.find_library('jacknet', required: get_option('jack_net'))
+
+dep_alsa = dependency('alsa', version: '>=1.0.18', required: alsa_required)
 dep_opus = dependency('opus', version: '>=0.9.0', required: get_option('opus_support'))
 dep_readline = dependency('readline', required: get_option('readline_support'))
 dep_samplerate = dependency('samplerate', required: libsamplerate_required)
@@ -91,15 +139,6 @@ conf_data.set('DATE', '2022')
 c_args_common = [
   '-D__PROJECT_VERSION__="@0@"'.format(conf_data.get('VERSION')),
 ]
-
-if jack_version.version_compare('>=0.109.0') and jack_version.version_compare('<0.200.0')
-  message('Detected jack1 compatible headers')
-  c_args_common += ['-D__JACK1__']
-endif
-if (jack_version.version_compare('>=0.58') and jack_version.version_compare('<=0.71')) or jack_version.version_compare('>=1.9.0')
-  message('Detected jack2 compatible headers')
-  c_args_common += ['-D__JACK2__']
-endif
 
 subdir('tools')
 subdir('example-clients')

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -126,7 +126,7 @@ if build_jack_netsource
     c_args_netsource += ['-DHAVE_OPUS']
     deps_netsource += [dep_opus]
   endif
-  if cc.has_function('ppoll', prefix : '#define _GNU_SOURCE\n#include <sys/poll.h>')
+  if has_ppoll
     c_args_netsource += ['-DHAVE_PPOLL']
   endif
 

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -74,9 +74,15 @@ exe_jack_load = executable(
   install: true
 )
 
+if has_jack1_internal_client and not has_jack2_internal_client
+  c_args_jack_unload = c_args_common + ['-D__JACK1__']
+endif
+if not has_jack1_internal_client and has_jack2_internal_client
+  c_args_jack_unload = c_args_common + ['-D__JACK2__']
+endif
 exe_jack_unload = executable(
   'jack_unload',
-  c_args: c_args_common,
+  c_args: c_args_jack_unload,
   sources: ['ipunload.c'],
   dependencies: [dep_jack],
   install: true


### PR DESCRIPTION
This adds the detection of JACK implementation specific features for `tools/ipunload.c` and `example-clients/server_control.c` with the help of meson's `cc.has_function()` and `cc.compiles()` checks. With the help of the pkgconfig variable `jack_implementation` which is added to jack1 0.126.0, jack2 1.9.20 and pipewire 0.3.44 the build system now emits a warning about potentially conflicting files during install, if no compatible jack implementation is found.

Additionally this updates the README by removing the warning about conflicting files (with the version check and emitted warning, users of this project are now aware of the fact that they are using an unsupported jack version to compile/ install it).