### PR TITLE
Fix portability issues with alloca()

### DIFF
--- a/common/netjack_packet.c
+++ b/common/netjack_packet.c
@@ -39,7 +39,6 @@
 #define _GNU_SOURCE
 #endif
 
-#include <alloca.h>
 #include <math.h>
 #include <stdio.h>
 #include <memory.h>

--- a/tools/alsa_out.c
+++ b/tools/alsa_out.c
@@ -4,7 +4,6 @@
  * as they would be used by many applications.
  */
 
-#include <alloca.h>
 #include <stdio.h>
 #include <errno.h>
 #include <unistd.h>

--- a/tools/session_notify.c
+++ b/tools/session_notify.c
@@ -19,7 +19,6 @@
  *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#include <alloca.h>
 #include <stdio.h>
 #include <errno.h>
 #include <unistd.h>


### PR DESCRIPTION
As discussed on IRC: `alloca()` is a method to allocate dynamic memory on the stack. It is non-standard, although implemented on most platforms. In general it is superseded by the variable length array feature in C99.

The problem on FreeBSD is that there is no `alloca.h` header. Jack2 has an extra header in `compat/alloca/alloca.h` for systems where the `alloca.h` header is not present, specifically windows.

I can offer 3 ways to deal with this, thus 3 commits...

1. Just remove the `alloca.h` includes. That may already be enough, because `stdlib.h` should include `alloca()` on platforms that implement it, and `tools/netsource.c` seems to be fine currently without the `alloca.h` include.
2. Inline the Windows compatibility header from jack2, just to make sure we have no regressions.
3. Replace all calls to `alloca()` with variable length arrays. Changes are rather trivial, but still more risky than 1. and 2.