### PR TITLE
CI integration for pipewire-jack

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,3 +40,18 @@ jobs:
         run: meson build && ninja -C build
       - name: Install jack-example-tools
         run: ninja -C build install
+  build_arch_linux_pipewire_jack:
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: pacman --noconfirm -Syu alsa-lib base-devel celt meson opus readline libsamplerate libsndfile zita-alsa-pcmi zita-resampler
+      - name: Install pipewire-jack
+        run: pacman --noconfirm -S pipewire-jack
+      # disable jack_net support for now: https://github.com/jackaudio/jack-example-tools/issues/61
+      - name: Build jack-example-tools
+        run: meson -Djack_net=disabled build && ninja -C build
+      - name: Install jack-example-tools
+        run: ninja -C build install

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ options](https://mesonbuild.com/Builtin-options.html#universal-options) (e.g.
 meson --prefix=/usr build
 ```
 
+**NOTE**: Currently it is not possible to use pipewire-jack to build tooling
+that requires **jack_net** support (see
+[#61](https://github.com/jackaudio/jack-example-tools/issues/61)).
+
 To build the applications and libraries [ninja](https://ninja-build.org/) is
 required:
 


### PR DESCRIPTION
This adds CI integration for building the project using pipewire-jack, while ignoring the build of net_jack tooling (see #61).
This also adds a note to the README about the build issues.