### PR TITLE
Pipewire 0.3.44

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,8 +50,7 @@ jobs:
         run: pacman --noconfirm -Syu alsa-lib base-devel celt meson opus readline libsamplerate libsndfile zita-alsa-pcmi zita-resampler
       - name: Install pipewire-jack
         run: pacman --noconfirm -S pipewire-jack
-      # disable jack_net support for now: https://github.com/jackaudio/jack-example-tools/issues/61
       - name: Build jack-example-tools
-        run: meson -Djack_net=disabled build && ninja -C build
+        run: meson build && ninja -C build
       - name: Install jack-example-tools
         run: ninja -C build install

--- a/README.md
+++ b/README.md
@@ -44,10 +44,6 @@ options](https://mesonbuild.com/Builtin-options.html#universal-options) (e.g.
 meson --prefix=/usr build
 ```
 
-**NOTE**: Currently it is not possible to use pipewire-jack to build tooling
-that requires **jack_net** support (see
-[#61](https://github.com/jackaudio/jack-example-tools/issues/61)).
-
 To build the applications and libraries [ninja](https://ninja-build.org/) is
 required:
 


### PR DESCRIPTION
Arch Linux now ships pipewire 0.3.44, so we can use it in CI to build all features.

Fixes #61