### PR TITLE
Bad semaphore allocation in midi_latency_test.

### DIFF
--- a/example-clients/midi_latency_test.c
+++ b/example-clients/midi_latency_test.c
@@ -163,7 +163,7 @@ create_semaphore(int id)
         semaphore = NULL;
     }
 #else
-    semaphore = malloc(sizeof(semaphore_t));
+    semaphore = malloc(sizeof(sem_t));
     if (semaphore != NULL) {
         if (sem_init(semaphore, 0, 0)) {
             free(semaphore);


### PR DESCRIPTION
The code did a pointer-sized heap allocation instead of the actual size
of a semaphore struct sem_t. This could result in heap memory corruption
when handling the semaphore.
Found by llvm scan-build.

This commit is also part of https://github.com/jackaudio/jack2/pull/844