### PR TITLE
Fix doc simple client

### DIFF
--- a/example-clients/simple_client.c
+++ b/example-clients/simple_client.c
@@ -43,7 +43,8 @@ static void signal_handler(int sig)
  * special realtime thread once for each audio cycle.
  *
  * This client follows a simple rule: when the JACK transport is
- * running, copy the input port to the output.  When it stops, exit.
+ * running, write nframes sine wave samples to the two outputs ports.
+ * When it stops, exit.
  */
 
 int

--- a/man/jack_simple_client.0
+++ b/man/jack_simple_client.0
@@ -8,9 +8,9 @@ client-name
 The client-name must be a yet unused client name.
 .SH DESCRIPTION
 .B jack_simple_client
-is an example client for the JACK Audio Connection Kit. It creates two
-ports (client-name:input and client-name:output) that pass the data
-unmodified.
+is an example client for the JACK Audio Connection Kit. It creates two output
+ports (client-name:output1 and client-name:output2) and plays a sine wave
+to these ports.
 .SH EXAMPLE
 jack_simple_client in_process_test
 .SH AUTHOR


### PR DESCRIPTION
Since version 1.9.20 of JACK, the simple client feature has changed but the documentation (manpage and source-code comments) has not been updated and could confuse people who are working with JACK.
These commits are created to fix:

- The manpage description (in jack-example-tools/man/jack_simple_client.0)
- The source-code description (in jack-example-tools/example-clients/simple_client.c)