### PR TITLE
Remove (specific) use of celt from CI setup

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,24 +2,15 @@ task:
   freebsd_instance:
     matrix:
       - image_family: freebsd-12-3
-      - image_family: freebsd-13-0
+      - image_family: freebsd-13-1
 
   environment:
     CFLAGS: -O2 -pipe -fPIC -fstack-protector-strong -fno-strict-aliasing -I/usr/local/include
     CPPFLAGS: -O2 -pipe -fPIC -fstack-protector-strong -fno-strict-aliasing -I/usr/local/include
     LDFLAGS: -lreadline -L/usr/local/lib -fstack-protector-strong
 
-  # Install jack2 from source - replace by package once 1.9.20 is out.
   jack2_dependencies_script:
-    - pkg install -y pkgconf python3 libsndfile libsamplerate libsysinfo readline alsa-lib dbus expat opus git
-  jack2_source_script:
-    - git clone --branch develop --depth 1 https://github.com/jackaudio/jack2.git /jack2
-  jack2_config_script:
-    - cd /jack2 && python3 ./waf configure --celt=no --sndfile=yes --samplerate=yes --alsa=yes --dbus --classic --autostart=dbus --readline=yes --opus=yes --example-tools=no --prefix /usr/local --pkgconfigdir libdata/pkgconfig
-  jack2_build_script:
-    - cd /jack2 && python3 ./waf
-  jack2_install_script:
-    - cd /jack2 && python3 ./waf install
+    - pkg install -y jackit pkgconf python3 libsndfile libsamplerate libsysinfo readline alsa-lib dbus expat opus git
 
   prepare_script:
     - mkdir /Install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     container:
       image: archlinux:latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Add pro-audio-legacy repository
         run: |
           printf "[pro-audio-legacy]\nServer = https://pkgbuild.com/~dvzrv/repos/pro-audio-legacy/\$arch\n" >> /etc/pacman.conf
@@ -37,7 +37,7 @@ jobs:
     container:
       image: archlinux:latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: pacman --noconfirm -Syu alsa-lib base-devel jack2 meson opus readline libsamplerate libsndfile zita-alsa-pcmi zita-resampler
       - name: Build jack-example-tools
@@ -49,7 +49,7 @@ jobs:
     container:
       image: archlinux:latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: pacman --noconfirm -Syu alsa-lib base-devel meson opus pipewire-jack readline libsamplerate libsndfile zita-alsa-pcmi zita-resampler
       - name: Build jack-example-tools
@@ -61,7 +61,7 @@ jobs:
     container:
       image: alpine:latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: apk add g++ meson pkgconf alsa-lib-dev jack-dev opus-dev readline-dev libsamplerate-dev libsndfile-dev
       - name: Build jack-example-tools
@@ -71,7 +71,7 @@ jobs:
   build_macos_latest:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: brew install jack meson opus pkg-config readline
       - name: Build jack-example-tools
@@ -81,9 +81,9 @@ jobs:
   build_pawpaw_macos_intel:
     runs-on: macos-10.15
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/PawPawBuilds
           key: macos-intel-v${{ env.PAWPAW_CACHE_VERSION }}
@@ -114,9 +114,9 @@ jobs:
   build_pawpaw_macos_universal:
     runs-on: macos-10.15
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/PawPawBuilds
           key: macos-universal-v${{ env.PAWPAW_CACHE_VERSION }}
@@ -151,9 +151,9 @@ jobs:
   build_pawpaw_win32:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/PawPawBuilds
           key: win32-v${{ env.PAWPAW_CACHE_VERSION }}
@@ -161,7 +161,8 @@ jobs:
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update -qq
-          sudo apt-get install -yqq --allow-downgrades libpcre2-8-0/focal libpcre2-16-0/focal libpcre2-32-0/focal libpcre2-posix2/focal
+          sudo apt-get install -yqq --allow-downgrades libgd3/focal libpcre2-8-0/focal libpcre2-16-0/focal libpcre2-32-0/focal libpcre2-posix2/focal
+          sudo apt-get purge -yqq libclang* libgbm* libllvm* libmono* moby* mono* php* libgdiplus libpcre2-posix3 libzip4
       - name: Set up dependencies
         run: |
           sudo dpkg --add-architecture i386
@@ -194,9 +195,9 @@ jobs:
   build_pawpaw_win64:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/PawPawBuilds
           key: win64-v${{ env.PAWPAW_CACHE_VERSION }}
@@ -204,7 +205,8 @@ jobs:
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update -qq
-          sudo apt-get install -yqq --allow-downgrades libpcre2-8-0/focal libpcre2-16-0/focal libpcre2-32-0/focal libpcre2-posix2/focal
+          sudo apt-get install -yqq --allow-downgrades libgd3/focal libpcre2-8-0/focal libpcre2-16-0/focal libpcre2-32-0/focal libpcre2-posix2/focal
+          sudo apt-get purge -yqq libclang* libgbm* libllvm* libmono* moby* mono* php* libgdiplus libpcre2-posix3 libzip4
       - name: Set up dependencies
         run: |
           sudo dpkg --add-architecture i386

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,13 +22,12 @@ jobs:
       image: archlinux:latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install dependencies
-        run: pacman --noconfirm -Syu alsa-lib base-devel celt meson opus readline libsamplerate libsndfile zita-alsa-pcmi zita-resampler
-      - name: Install jack1
+      - name: Add pro-audio-legacy repository
         run: |
           printf "[pro-audio-legacy]\nServer = https://pkgbuild.com/~dvzrv/repos/pro-audio-legacy/\$arch\n" >> /etc/pacman.conf
           pacman -Syy
-          pacman --noconfirm -S jack
+      - name: Install dependencies
+        run: pacman --noconfirm -Syu alsa-lib base-devel jack meson opus readline libsamplerate libsndfile zita-alsa-pcmi zita-resampler
       - name: Build jack-example-tools
         run: meson build && ninja -C build
       - name: Install jack-example-tools
@@ -40,9 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
-        run: pacman --noconfirm -Syu alsa-lib base-devel celt meson opus readline libsamplerate libsndfile zita-alsa-pcmi zita-resampler
-      - name: Install jack2
-        run: pacman --noconfirm -S jack2
+        run: pacman --noconfirm -Syu alsa-lib base-devel jack2 meson opus readline libsamplerate libsndfile zita-alsa-pcmi zita-resampler
       - name: Build jack-example-tools
         run: meson build && ninja -C build
       - name: Install jack-example-tools
@@ -54,9 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
-        run: pacman --noconfirm -Syu alsa-lib base-devel celt meson opus readline libsamplerate libsndfile zita-alsa-pcmi zita-resampler
-      - name: Install pipewire-jack
-        run: pacman --noconfirm -S pipewire-jack
+        run: pacman --noconfirm -Syu alsa-lib base-devel meson opus pipewire-jack readline libsamplerate libsndfile zita-alsa-pcmi zita-resampler
       - name: Build jack-example-tools
         run: meson build && ninja -C build
       - name: Install jack-example-tools


### PR DESCRIPTION
.github/workflows/build.yml:
Drop celt from the list of dependencies of all Arch Linux targets (only
jack1 requires it and pulls it in automatically using the custom
pro-audio-legacy repository).
Combine the installation of the jack provider with the installation of
the remaining requirements for faster installation on Arch Linux targets.