### PR TITLE
CI: Update FreeBSD images to 13.2-RELEASE and 14.0-RELEASE.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,8 +1,8 @@
 task:
   freebsd_instance:
     matrix:
-      - image_family: freebsd-12-3
-      - image_family: freebsd-13-1
+      - image_family: freebsd-13-2
+      - image_family: freebsd-14-0
 
   environment:
     CFLAGS: -O2 -pipe -fPIC -fstack-protector-strong -fno-strict-aliasing -I/usr/local/include


### PR DESCRIPTION
Update Cirrus CI images to current releases of FreeBSD. Don't have permission to push changes directly.