### PR TITLE
jack_load_test: fix parameter help

### DIFF
--- a/tools/load_test.c
+++ b/tools/load_test.c
@@ -26,7 +26,7 @@ show_usage (void)
 	fprintf (stderr, "\nUsage: %s [options]\n", my_name);
 	fprintf (stderr, "this is a test client, which just sleeps in its process_cb to simulate cpu load\n");
 	fprintf (stderr, "options:\n");
-	fprintf (stderr, "        -t, --timeout         Wait timeout in seconds\n");
+	fprintf (stderr, "        -t, --timeout         Wait timeout in microseconds\n");
 	fprintf (stderr, "        -h, --help            Display this help message\n");
 	fprintf (stderr, "        --version             Output version information and exit\n\n");
 	fprintf (stderr, "For more information see http://jackaudio.org/\n");


### PR DESCRIPTION
The help text of jack_load_test says:

```console
        -t, --timeout         Wait timeout in seconds
```

But the time is interpreted as microseconds:

See:

https://github.com/jackaudio/jack-example-tools/blob/767acf0c93cbcccefd4d9ad89bb6779caffcf2b4/tools/load_test.c#L49

which calls `jack_get_time()`

https://jackaudio.org/api/group__TimeFunctions.html#ga3b26460e62a56cf012e9075dcb1b6294

but `jack_get_time` returns microseconds. This PR just updates the help text to describe the current behaviour.