### PR TITLE
jack_lsp: Fix buffer overflow for --server argument

### DIFF
--- a/tools/lsp.c
+++ b/tools/lsp.c
@@ -122,7 +122,8 @@ main (int argc, char *argv[])
 	while ((c = getopt_long (argc, argv, "s:AclLphvtuU", long_options, &option_index)) >= 0) {
 		switch (c) {
 		case 's':
-			server_name = (char *) malloc (sizeof (char) * strlen(optarg));
+			server_name = (char *) malloc (sizeof (char) * (strlen(optarg) + 1));
+			server_name[strlen(optarg)] = '\0';
 			strcpy (server_name, optarg);
 			options |= JackServerName;
 			break;


### PR DESCRIPTION
In the copied `optarg` there are only chars from the argument, no string termination `\0` char. That causes the following code to go beyond the variable memory bound.

This change adds one extra char allocation for the `server_name` variable and puts `\0` string termination char to the last char.

Fixes https://github.com/jackaudio/jack-example-tools/issues/88