### PR TITLE
CI: Update FreeBSD images to 13.3-RELEASE and 14.1-RELEASE.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,8 +1,8 @@
 task:
   freebsd_instance:
     matrix:
-      - image_family: freebsd-13-2
-      - image_family: freebsd-14-0
+      - image_family: freebsd-13-3
+      - image_family: freebsd-14-1
 
   environment:
     CFLAGS: -O2 -pipe -fPIC -fstack-protector-strong -fno-strict-aliasing -I/usr/local/include


### PR DESCRIPTION
Time goes by...

Update the Cirrus FreeBSD images for CI to 13.3-RELEASE and 14.1-RELEASE, just that.