### PR TITLE
Fix default resampling quality selection

### DIFF
--- a/tools/zalsa/zita-a2j.cc
+++ b/tools/zalsa/zita-a2j.cc
@@ -287,8 +287,6 @@ public:
             delete this;
             return 1;
         }
-        if (rqual < 16) rqual = 16;
-        if (rqual > 96) rqual = 96;
         if ((fsamp < 8000) || (bsize < 16) || (nfrag < 2) || (nchan < 1))
         {
             jack_error (APPNAME ": Illegal parameter value(s).");

--- a/tools/zalsa/zita-j2a.cc
+++ b/tools/zalsa/zita-j2a.cc
@@ -285,8 +285,6 @@ public:
             delete this;
             return 1;
         }
-        if (rqual < 16) rqual = 16;
-        if (rqual > 96) rqual = 96;
         if ((fsamp < 8000) || (bsize < 16) || (nfrag < 2) || (nchan < 1))
         {
             jack_error (APPNAME ": Illegal parameter value(s).");


### PR DESCRIPTION
When the user doesn't explicitly specify the resampling quality using the `-Q` flag, the quality should be calculated based on Jack's server sampling rate.

This isn't the case, because the `rqual` variable is always set to 16 in `jack_initialize`. This results in the quality always being 16.

To fix this and make the behavior the same as the `zita-ajbridge` tools, the redundant `rqual` clamping of the value to the range `[16,96]` should be removed from `jack_initialize()`, because this is done later in `jack_initialize_part2()` only AFTER the quality calculation.